### PR TITLE
removing invalid params

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -20,8 +20,8 @@ jobs:
 
       - name: Build package
         run: |
-          rm -rf dist/ build/
-          poetry install --no-dev
+          rm -rf dist/
+          poetry install
           poetry build
 
       - name: Upload to Test PyPI


### PR DESCRIPTION
--no-dev was not defined and was making the action crash.